### PR TITLE
[Swarm] Healthcare Access Index Calculator

### DIFF
--- a/src/healthcare_index.py
+++ b/src/healthcare_index.py
@@ -1,0 +1,99 @@
+import pandas as pd
+import numpy as np
+from scipy import stats
+import logging
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+
+def normalize_metric(data: pd.Series) -> pd.Series:
+    """Normalizes a healthcare metric to a range of 0-1.
+
+    Args:
+        data (pd.Series): A pandas Series containing the metric values.
+
+    Returns:
+        pd.Series: A pandas Series containing the normalized metric values.
+    """
+    try:
+        min_val = data.min()
+        max_val = data.max()
+        if min_val == max_val:
+            logging.warning("Normalization failed: min and max values are equal.")
+            return pd.Series(np.zeros(len(data)))
+        normalized_data = (data - min_val) / (max_val - min_val)
+        return normalized_data
+    except Exception as e:
+        logging.error(f"Error during normalization: {e}")
+        return pd.Series(np.zeros(len(data)))
+
+
+def compute_composite_index(data: pd.DataFrame, weights: dict) -> pd.Series:
+    """Computes a weighted composite index for healthcare access.
+
+    Args:
+        data (pd.DataFrame): A pandas DataFrame containing normalized healthcare metrics.
+        weights (dict): A dictionary specifying the weights for each metric.
+
+    Returns:
+        pd.Series: A pandas Series containing the composite index scores.
+    """
+    try:
+        composite_index = pd.Series(np.zeros(len(data)), index=data.index)
+        for metric, weight in weights.items():
+            if metric not in data.columns:
+                raise ValueError(f"Metric '{metric}' not found in the data.")
+            composite_index += data[metric] * weight
+        return composite_index
+    except ValueError as ve:
+        logging.error(f"ValueError during composite index computation: {ve}")
+        return pd.Series(np.zeros(len(data)), index=data.index)
+    except Exception as e:
+        logging.error(f"Error during composite index computation: {e}")
+        return pd.Series(np.zeros(len(data)), index=data.index)
+
+
+def rank_countries(index_scores: pd.Series, confidence_interval: float = 0.95) -> pd.DataFrame:
+    """Ranks countries by healthcare access index and provides confidence intervals.
+
+    Args:
+        index_scores (pd.Series): A pandas Series containing the composite index scores.
+        confidence_interval (float): The desired confidence interval (default: 0.95).
+
+    Returns:
+        pd.DataFrame: A pandas DataFrame containing the ranked countries, index scores,
+                      mean, standard error, and confidence interval bounds.
+    """
+    try:
+        ranked_countries = index_scores.sort_values(ascending=False).to_frame(name='index_score')
+        mean = index_scores.mean()
+        std_err = stats.sem(index_scores)
+        interval = std_err * stats.t.ppf((1 + confidence_interval) / 2, len(index_scores) - 1)
+        ranked_countries['mean'] = mean
+        ranked_countries['standard_error'] = std_err
+        ranked_countries['confidence_interval_lower'] = mean - interval
+        ranked_countries['confidence_interval_upper'] = mean + interval
+        return ranked_countries
+    except Exception as e:
+        logging.error(f"Error during country ranking: {e}")
+        return pd.DataFrame()
+
+
+def identify_outliers(index_scores: pd.Series, threshold: float = 3.0) -> pd.Series:
+    """Identifies statistical outliers in the healthcare access index.
+
+    Args:
+        index_scores (pd.Series): A pandas Series containing the composite index scores.
+        threshold (float): The Z-score threshold for identifying outliers (default: 3.0).
+
+    Returns:
+        pd.Series: A pandas Series containing the identified outliers.
+    """
+    try:
+        z_scores = np.abs(stats.zscore(index_scores))
+        outliers = index_scores[z_scores > threshold]
+        return outliers
+    except Exception as e:
+        logging.error(f"Error during outlier identification: {e}")
+        return pd.Series()

--- a/tests/test_healthcare_index.py
+++ b/tests/test_healthcare_index.py
@@ -1,0 +1,97 @@
+import pytest
+import pandas as pd
+import numpy as np
+from src import healthcare_index
+import logging
+
+# Suppress logging during tests
+logging.disable(logging.CRITICAL)
+
+
+@pytest.fixture
+def sample_data():
+    """Fixture to provide sample healthcare data."""
+    data = {
+        'country': ['USA', 'Canada', 'Mexico'],
+        'life_expectancy': [78.0, 82.0, 75.0],
+        'access_to_healthcare': [0.9, 0.95, 0.8],
+        'infant_mortality': [5.0, 4.0, 6.0]
+    }
+    return pd.DataFrame(data)
+
+
+def test_normalize_metric(sample_data):
+    """Test the normalize_metric function."""
+    life_expectancy = sample_data['life_expectancy']
+    normalized_life_expectancy = healthcare_index.normalize_metric(life_expectancy)
+    assert isinstance(normalized_life_expectancy, pd.Series)
+    assert normalized_life_expectancy.min() == 0.0
+    assert normalized_life_expectancy.max() == 1.0
+
+
+def test_normalize_metric_edge_case_same_values():
+    """Test normalize_metric with all values the same."""
+    data = pd.Series([5, 5, 5, 5])
+    normalized_data = healthcare_index.normalize_metric(data)
+    assert all(normalized_data == 0.0)
+
+
+def test_compute_composite_index(sample_data):
+    """Test the compute_composite_index function."""
+    # Normalize the data
+    normalized_data = sample_data[['life_expectancy', 'access_to_healthcare', 'infant_mortality']].copy()
+    for col in normalized_data.columns:
+        normalized_data[col] = healthcare_index.normalize_metric(sample_data[col])
+
+    weights = {'life_expectancy': 0.4, 'access_to_healthcare': 0.4, 'infant_mortality': 0.2}
+    composite_index = healthcare_index.compute_composite_index(normalized_data, weights)
+    assert isinstance(composite_index, pd.Series)
+    assert len(composite_index) == len(sample_data)
+
+
+def test_compute_composite_index_missing_metric(sample_data):
+    """Test compute_composite_index with a missing metric."""
+    normalized_data = sample_data[['life_expectancy', 'access_to_healthcare']].copy()
+    for col in normalized_data.columns:
+        normalized_data[col] = healthcare_index.normalize_metric(sample_data[col])
+    weights = {'life_expectancy': 0.5, 'access_to_healthcare': 0.5, 'missing_metric': 0.2}
+    with pytest.raises(ValueError):
+        healthcare_index.compute_composite_index(normalized_data, weights)
+
+
+def test_rank_countries(sample_data):
+    """Test the rank_countries function."""
+    # Normalize the data
+    normalized_data = sample_data[['life_expectancy', 'access_to_healthcare', 'infant_mortality']].copy()
+    for col in normalized_data.columns:
+        normalized_data[col] = healthcare_index.normalize_metric(sample_data[col])
+
+    weights = {'life_expectancy': 0.4, 'access_to_healthcare': 0.4, 'infant_mortality': 0.2}
+    composite_index = healthcare_index.compute_composite_index(normalized_data, weights)
+    ranked_countries = healthcare_index.rank_countries(composite_index)
+    assert isinstance(ranked_countries, pd.DataFrame)
+    assert 'index_score' in ranked_countries.columns
+    assert 'mean' in ranked_countries.columns
+    assert 'standard_error' in ranked_countries.columns
+    assert 'confidence_interval_lower' in ranked_countries.columns
+    assert 'confidence_interval_upper' in ranked_countries.columns
+
+
+def test_rank_countries_empty_index():
+    """Test rank_countries with an empty index."""
+    index_scores = pd.Series([])
+    ranked_countries = healthcare_index.rank_countries(index_scores)
+    assert isinstance(ranked_countries, pd.DataFrame)
+
+
+def test_identify_outliers(sample_data):
+    """Test the identify_outliers function."""
+    # Normalize the data
+    normalized_data = sample_data[['life_expectancy', 'access_to_healthcare', 'infant_mortality']].copy()
+    for col in normalized_data.columns:
+        normalized_data[col] = healthcare_index.normalize_metric(sample_data[col])
+
+    weights = {'life_expectancy': 0.4, 'access_to_healthcare': 0.4, 'infant_mortality': 0.2}
+    composite_index = healthcare_index.compute_composite_index(normalized_data, weights)
+    outliers = healthcare_index.identify_outliers(composite_index)
+    assert isinstance(outliers, pd.Series)


### PR DESCRIPTION
## Healthcare Access Index Calculator

Create src/healthcare_index.py: Implement a Healthcare Access Index (HAI) calculator that processes WHO health indicators. Include functions to: (1) normalize healthcare metrics across countries, (2) compute weighted composite index scores, (3) rank countries by access level with confidence intervals, (4) identify statistical outliers. Write tests in tests/test_healthcare_index.py covering edge cases like missing data and zero-division.

### Review Process
- **1 agents** competed independently
- AI reviewer evaluated and synthesized the best solution


### Files
- `src/healthcare_index.py`
- `tests/test_healthcare_index.py`

### Contributors
- `node_8c42a1cccaf2` (TasteIsAllYouNeed) -- rep: 94.2

Co-authored-by: EvoMap-Agent-8c42a1cc <node_8c42a1cccaf2@agents.evomap.ai>