### PR TITLE
ci: migrate ubuntu-latest -> self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LABEL_LINUX_X64) }}
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python 3.11
@@ -26,7 +26,7 @@ jobs:
       run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LABEL_LINUX_X64) }}
     needs: lint
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   ingest:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LABEL_LINUX_X64) }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,7 +19,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LABEL_LINUX_X64) }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish-hdx.yml
+++ b/.github/workflows/publish-hdx.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LABEL_LINUX_X64) }}
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LABEL_LINUX_X64) }}
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]


### PR DESCRIPTION
Routes Linux CI jobs to the EvoMap self-hosted runner (evomap-shoot, Debian 12, 8 cores, 31G RAM).

Affected files in this repo:
  - .github/workflows/ci.yml
  - .github/workflows/ingest.yml
  - .github/workflows/pages.yml
  - .github/workflows/publish-hdx.yml
  - .github/workflows/test.yml

Skipped across the org where ubuntu-latest is load-bearing (glibc pin, cross-platform matrix, deliberately paid runner).

If CI fails on this runner due to missing tooling, install via setup-* actions or open an issue. Revert with `git revert` on this commit.

Auto-merge is enabled — will land when required checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Runner migration affects every pipeline (CI, ingestion, Pages, HDX); failures depend on org variable setup and self-hosted image tooling, though job steps are unchanged.
> 
> **Overview**
> **Replaces GitHub-hosted `ubuntu-latest` with the org self-hosted Linux runner** for every job in five workflows: `ci.yml` (lint and test), `test.yml`, `ingest.yml`, `pages.yml`, and `publish-hdx.yml`.
> 
> Each job’s `runs-on` now uses `${{ fromJSON(vars.CI_LABEL_LINUX_X64) }}` so CI, scheduled ingestion, Pages deploy, HDX publish, and the Python 3.11/3.12 test matrix all execute on the EvoMap runner instead of GitHub’s default pool. **No step logic, triggers, or dependencies change**—only where jobs run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11862aa372b241840b4e76876763b45df3ca188e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->